### PR TITLE
fix: narrow floating nav with horizontal margin on mobile

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -57,7 +57,7 @@ const Layout = ({ children, noHeader, noFooter }) => {
       <div className="text-white bg-standard [background-image:linear-gradient(color-mix(in_srgb,var(--color-blue-ncs)_10%,transparent)_1px,transparent_1px),linear-gradient(90deg,color-mix(in_srgb,var(--color-blue-ncs)_10%,transparent)_1px,transparent_1px)] [background-size:40px_40px] bg-fixed min-h-screen">
         <Headroom onPin={onHeaderFloat} onUnfix={onHeaderUnfloat}>
           <div className={cx(
-            "transition-all duration-300",
+            "transition-all duration-300 mx-2 desktop:mx-0",
             floatingHeader ? "bg-[color-mix(in_srgb,var(--color-caribbean-green)_90%,transparent)] shadow-[0_2px_2px_color-mix(in_srgb,var(--color-black)_75%,transparent)]" : "bg-transparent shadow-none",
             noHeader && !floatingHeader && "opacity-0 pointer-events-none"
           )}>


### PR DESCRIPTION
The floating header bar was stretching edge-to-edge on mobile,
out of sync with page content below. Add small horizontal margin
on mobile viewports so the nav no longer touches the screen edges
while preserving the existing desktop layout.