### PR TITLE
fix: allow testimonial author to wrap on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -496,6 +496,10 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    flex-wrap: wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    min-width: 0;
   }
 
   .testimonial-logo {


### PR DESCRIPTION
Long names with underscores (e.g. Alexandre_Van_de_Sande) were causing
horizontal overflow on narrow viewports because underscores are not valid
break points. Enable flex-wrap plus overflow-wrap: anywhere on the author
row so the name breaks within the container.