### PR TITLE
Remove desktop-specific margin from header layout

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -57,7 +57,7 @@ const Layout = ({ children, noHeader, noFooter }) => {
       <div className="text-white bg-standard [background-image:linear-gradient(color-mix(in_srgb,var(--color-blue-ncs)_10%,transparent)_1px,transparent_1px),linear-gradient(90deg,color-mix(in_srgb,var(--color-blue-ncs)_10%,transparent)_1px,transparent_1px)] [background-size:40px_40px] bg-fixed min-h-screen">
         <Headroom onPin={onHeaderFloat} onUnfix={onHeaderUnfloat}>
           <div className={cx(
-            "transition-all duration-300 mx-2 desktop:mx-0",
+            "transition-all duration-300 mx-0",
             floatingHeader ? "bg-[color-mix(in_srgb,var(--color-caribbean-green)_90%,transparent)] shadow-[0_2px_2px_color-mix(in_srgb,var(--color-black)_75%,transparent)]" : "bg-transparent shadow-none",
             noHeader && !floatingHeader && "opacity-0 pointer-events-none"
           )}>


### PR DESCRIPTION
## Summary
Simplified the header styling by removing the responsive margin behavior that applied `mx-0` only on desktop viewports.

## Changes
- Removed the `desktop:mx-0` responsive utility class from the header container
- Changed from `"transition-all duration-300 mx-2 desktop:mx-0"` to `"transition-all duration-300 mx-0"`
- This makes the header consistently use zero horizontal margin across all screen sizes instead of having `mx-2` on mobile and `mx-0` on desktop

## Details
This change unifies the header margin behavior by applying `mx-0` universally, eliminating the previous responsive breakpoint that adjusted margins based on viewport size. The header will now have consistent horizontal spacing regardless of device.

https://claude.ai/code/session_01FDWT5SLkStA5zvoQ38GyPd