### PR TITLE
Replace portfolio link with services page navigation

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -63,12 +63,7 @@ const IndexPage = () => {
               <p className="desc text-md max-w-[600px] leading-body"><strong>20+ years</strong> building full-stack apps and enabling technical teams. From blockchains to production SaaS.</p>
               <div className="btn-container">
                 <BookCallButton />
-                <a
-                  href="#work"
-                  className="cyber-btn"
-                  data-tooltip-id="app-tooltip"
-                  data-tooltip-content="View my work"
-                >./view_portfolio.sh</a>
+                <CyberLink to="/services" className="cyber-btn" tooltip="View all service offerings">./view_services.sh</CyberLink>
               </div>
             </div>
             <img className="hero-img" src="/ram.png" alt="Hiddentao Labs" />


### PR DESCRIPTION
## Summary
Updated the hero section call-to-action button to navigate to the services page instead of scrolling to a portfolio section, and refactored the link component for better maintainability.

## Key Changes
- Replaced anchor link (`#work`) with client-side routing to `/services` page
- Converted from standard `<a>` tag to `<CyberLink>` component for consistent routing behavior
- Updated button text from `./view_portfolio.sh` to `./view_services.sh` to reflect new destination
- Simplified tooltip implementation by passing `tooltip` prop directly to `<CyberLink>` component instead of using separate `data-tooltip-*` attributes

## Implementation Details
- The change maintains the existing "cyber-btn" styling and visual appearance
- Uses the application's routing system (`to` prop) instead of hash-based navigation, enabling better page management and analytics tracking
- Consolidates tooltip configuration into a single prop for cleaner JSX

https://claude.ai/code/session_01QmkjeuUigpN5f7H8dzwQmW